### PR TITLE
Upgrade to react-router 1.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>react-router</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <name>React Router</name>
     <description>WebJar for React Router</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1.0.0</upstream.version>
+        <upstream.version>1.0.3</upstream.version>
         <upstream.url>https://npmcdn.com/react-router@${upstream.version}/umd</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${version}</destDir>
         <requirejs>
@@ -55,19 +55,6 @@
         <developerConnection>scm:git:https://github.com/webjars/react-router.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>when-node</artifactId>
-            <version>3.5.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>events</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
I also removed the two dependencies on events and when-node.  I'm not sure why they were ever there in the first place, react-router has never depended on either of those dependencies in its package.json or bower.json files, and there's no mention of needing those in the documentation, so I guess they were accidentally left in there when the webjar was copied from another webjar that did depend on them?