### PR TITLE
Remove unnecessary shim section with obsolete dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,6 @@
             {
                 "paths": {
                     "react-router": "ReactRouter"
-                },
-                "shim": {
-                    "react-router": ["when", "events"]
                 }
             }
         </requirejs>


### PR DESCRIPTION
In `<requirejs>`section of `pom.xml` for an unknown reason we had  `"shim": {
                    "react-router": ["when", "events"]
                }`
This entry is wrong and prevents usage of `RequireJS.getSetupJavaScript` in a natural way.
The goal is to remove that part of configuration from `pom.xml`